### PR TITLE
[FEAT] 공통으로 사용할 예외처리

### DIFF
--- a/src/main/java/com/chonchul/common/exception/BusinessException.java
+++ b/src/main/java/com/chonchul/common/exception/BusinessException.java
@@ -1,0 +1,11 @@
+package com.chonchul.common.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BusinessException extends RuntimeException{
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/chonchul/common/exception/ErrorCode.java
+++ b/src/main/java/com/chonchul/common/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.chonchul.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String getCode();
+    HttpStatus getHttpStatus();
+    String getMessage();
+}

--- a/src/main/java/com/chonchul/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chonchul/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.chonchul.common.exception;
+
+import com.chonchul.common.response.FailureBody;
+import com.chonchul.common.response.ResponseEntityGenerator;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<FailureBody> handleConflict(BusinessException e) {
+        return ResponseEntityGenerator.fail(e.getErrorCode().getCode(), e.getErrorCode().getMessage(), e.getErrorCode().getHttpStatus());
+    }
+}


### PR DESCRIPTION
## 💻 관련 이슈
- [x] #12 

## 📋 PR 내용
common/exception 폴더에서 필요할 예외처리 코드를 작성하였습니다.
- 앞으로 예외 클래스는 BusinessException을 상속받습니다. 
- 앞으로 ErrorCode를 상속받아 도메인별로 에러코드를 enum으로 관리합니다. 
- BusinessException을 GlobalExceptionHandler에서 관리하도록 하였습니다.